### PR TITLE
feature: Implement wma prediction

### DIFF
--- a/src/main/java/com/example/spark/domain/wma/api/PredictionController.java
+++ b/src/main/java/com/example/spark/domain/wma/api/PredictionController.java
@@ -1,0 +1,56 @@
+package com.example.spark.domain.wma.api;
+
+
+import com.example.spark.domain.youtube.dto.YouTubeAnalysisResultDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import java.util.Map;
+import com.example.spark.global.response.SuccessResponse;
+import org.springframework.web.bind.annotation.RestController;
+import com.example.spark.domain.wma.service.PredictionService;
+import com.example.spark.domain.flask.dto.YouTubeDataCache;
+@Tag(name = "Prediction API", description = "3개월 뒤 조회수/구독자수를 계산하는 API")
+@RestController
+@RequiredArgsConstructor
+public class PredictionController {
+    private final PredictionService PredictionService;
+    private final YouTubeDataCache YouTubeDataCache;
+    
+    @Operation(
+            summary = "WMA 기반 성장 예측",
+            description = """
+                    최근 3개 기간의 조회수/구독자수 데이터를 기반으로
+                    3개월 뒤 조회수/구독자수를 가중 이동 평균(WMA)으로 예측합니다.
+                    
+                    **요청값**
+                    - `channelId`: 조회할 채널 ID
+                    
+                    **응답값**
+                    - 3개월 뒤 조회수 예측
+                    - 3개월 뒤 구독자수 예측
+                    """
+    )
+    @GetMapping("/channel-predictions")
+    public SuccessResponse<Map<String, Double>> getWmaPredictions(
+            @RequestParam String channelId) {
+
+        // 캐시에서 데이터 조회 후 즉시 삭제
+        YouTubeAnalysisResultDto analysisResult = YouTubeDataCache.getAndRemoveData(channelId);
+
+        if (analysisResult == null || analysisResult.getStats().size() < 3) {
+            throw new RuntimeException("WMA 예측을 위해 최소 3개 기간 데이터가 필요합니다.");
+        }
+
+        // WMA 기반 성장 예측 수행
+        Map<String, Double> wmaPredictions = PredictionService.calculateWMAPredictions(analysisResult.getStats());
+
+        return SuccessResponse.success(wmaPredictions);
+    }
+
+
+
+
+}

--- a/src/main/java/com/example/spark/domain/wma/service/PredictionService.java
+++ b/src/main/java/com/example/spark/domain/wma/service/PredictionService.java
@@ -1,0 +1,42 @@
+package com.example.spark.domain.wma.service;
+
+import com.example.spark.domain.youtube.dto.YouTubeCombinedStatsDto;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+
+@Service
+public class PredictionService {
+    public Map<String, Double> calculateWMAPredictions(List<YouTubeCombinedStatsDto> stats) {
+        if (stats.size() < 3) {
+            throw new RuntimeException("WMA 예측을 위해 최소 3개 기간 데이터가 필요합니다.");
+        }
+
+        // 가중치 설정 (최근 데이터에 더 높은 가중치)
+        double w1 = 0.5;
+        double w2 = 0.3;
+        double w3 = 0.2;
+
+        // 최근 3개 기간 데이터
+        double recentViews = stats.get(0).getViews();
+        double midViews = stats.get(1).getViews();
+        double oldViews = stats.get(2).getViews();
+
+        double recentSubscribers = stats.get(0).getNetSubscribers();
+        double midSubscribers = stats.get(1).getNetSubscribers();
+        double oldSubscribers = stats.get(2).getNetSubscribers();
+
+        // WMA 계산
+        double predictedViews = (w1 * recentViews) + (w2 * midViews) + (w3 * oldViews);
+        double predictedNetSubscribers = (w1 * recentSubscribers) + (w2 * midSubscribers) + (w3 * oldSubscribers);
+
+        // 결과 반환
+        Map<String, Double> predictions = new HashMap<>();
+        predictions.put("predictedViews", Double.valueOf((int) Math.round(predictedViews)));
+        predictions.put("predictedNetSubscribers", Double.valueOf((int) Math.round(predictedNetSubscribers)));
+
+        return predictions;
+    }
+}


### PR DESCRIPTION
가중 이동 평균(WMA) 계산을 사용한 데이터 예측
---

- 가중 이동 평균을 이용한 3개월 뒤 데이터 예측 API를 개발하였습니다.
- 통계 데이터를 원래 캐시에 보관하였다가 flask 서버로 보내고 해당 캐시데이터를 삭제하는 방식을 사용하였는데, flask 서버로 보내는 기능을 사용하지 않게 되면서, WMA 계산에 해당 데이터를 사용하게 되었습니다.
- 예측하는 항목은 구독자와 조회수입니다.
- 기간별 구독자/조회수 상승 %는 일단은 프론트단에서 계산하기로 하였고, 백엔드 개발 완성 후 여유가 된다면 백에서 계산하는 방식으로 할 예정입니다.


<img width="311" alt="image" src="https://github.com/user-attachments/assets/1c1cef05-66f0-41b5-8946-3b1e483e5abe" />
