### PR TITLE
feature: using refreshToken for Google Auth

### DIFF
--- a/src/main/java/com/example/spark/domain/youtube/api/OAuthController.java
+++ b/src/main/java/com/example/spark/domain/youtube/api/OAuthController.java
@@ -1,17 +1,21 @@
 package com.example.spark.domain.youtube.api;
 
-import com.example.spark.domain.youtube.dto.GoogleAuthRequest;
+import com.example.spark.global.oauth.GoogleAuthRequest;
+import com.example.spark.global.oauth.GoogleTokenRefreshRequest;
 import com.example.spark.global.response.GoogleTokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.bind.annotation.*;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
@@ -92,6 +96,48 @@ public class OAuthController {
             } else {
                 return ResponseEntity.status(response.getStatusCode())
                         .body(new GoogleTokenResponse("Error", "Failed to retrieve access token"));
+            }
+        } catch (Exception ex) {
+            return ResponseEntity.internalServerError()
+                    .body(new GoogleTokenResponse("Error", "Unexpected error occurred: " + ex.getMessage()));
+        }
+    }
+
+    @Operation(summary = "Refresh Token을 사용하여 Access Token 갱신", description = "Google의 Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.")
+    @PostMapping("/oauth/google/refresh")
+    public ResponseEntity<GoogleTokenResponse> refreshAccessToken(@RequestBody GoogleTokenRefreshRequest request) {
+        String refreshToken = request.getRefreshToken();
+
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            return ResponseEntity.badRequest().body(new GoogleTokenResponse("Error", "Refresh token is missing"));
+        }
+
+        // 요청 파라미터 생성
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("client_id", CLIENT_ID);
+        params.add("client_secret", CLIENT_SECRET);
+        params.add("refresh_token", refreshToken);
+        params.add("grant_type", "refresh_token");
+
+        // 요청 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        // 요청 생성
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+
+        // Google 서버로 요청 보내기
+        RestTemplate restTemplate = new RestTemplate();
+        try {
+            ResponseEntity<GoogleTokenResponse> response = restTemplate.postForEntity(
+                    TOKEN_ENDPOINT, requestEntity, GoogleTokenResponse.class);
+
+            if (response.getStatusCode().is2xxSuccessful()) {
+                GoogleTokenResponse tokenResponse = response.getBody();
+                return ResponseEntity.ok().body(tokenResponse);
+            } else {
+                return ResponseEntity.status(response.getStatusCode())
+                        .body(new GoogleTokenResponse("Error", "Failed to refresh access token"));
             }
         } catch (Exception ex) {
             return ResponseEntity.internalServerError()

--- a/src/main/java/com/example/spark/global/oauth/GoogleAuthRequest.java
+++ b/src/main/java/com/example/spark/global/oauth/GoogleAuthRequest.java
@@ -1,4 +1,4 @@
-package com.example.spark.domain.youtube.dto;
+package com.example.spark.global.oauth;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/spark/global/oauth/GoogleTokenRefreshRequest.java
+++ b/src/main/java/com/example/spark/global/oauth/GoogleTokenRefreshRequest.java
@@ -1,0 +1,11 @@
+package com.example.spark.global.oauth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+public class GoogleTokenRefreshRequest {
+
+    @Schema(description = "Google OAuth 2.0에서 받은 Refresh Token", example = "1//0g123abc456xyz789")
+    private String refreshToken;
+}


### PR DESCRIPTION
Refresh Token을 사용한 Access Token 갱신
---

- refresh_token을 이용하여 access_token을 갱신하는 기능을 구현합니다.
- refresh_token은 유저마다 변하지 않는 고유한 값으로 알고 있는데, 이 값을 어떻게 보관 할지에 대해서 논의가 필요할 것 같습니다. 

<img width="621" alt="image" src="https://github.com/user-attachments/assets/a69d1d93-01fb-4f37-8c9a-c6823275745e" />

<img width="599" alt="image" src="https://github.com/user-attachments/assets/1cba0caa-b72b-4313-8d30-ae9c14a10200" />
