### PR TITLE
refactor: Add custom error code in Auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.1'
-	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.springframework.boot' version '3.2.5'
+	id 'io.spring.dependency-management' version '1.1.4'
 	id 'com.google.protobuf' version '0.9.4'
 }
 
@@ -57,7 +57,7 @@ dependencies {
 	implementation 'com.nimbusds:nimbus-jose-jwt:8.4'
 
 	// openapi
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
 	// querydsl
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/main/java/com/example/spark/global/error/CustomException.java
+++ b/src/main/java/com/example/spark/global/error/CustomException.java
@@ -1,0 +1,14 @@
+package com.example.spark.global.error;
+
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/example/spark/global/error/ErrorCode.java
+++ b/src/main/java/com/example/spark/global/error/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.spark.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED.value(), "COMMON_008", "Access token expired"),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED.value(), "COMMON_012", "Refresh token expired"),
+    UNEXPECTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "COMMON_999", "Unexpected error occurred"),
+    INVALID_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST.value(), "COMMON_013", "Invalid authorization code"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "COMMON_999", "Unexpected error occurred");
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/spark/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/spark/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.example.spark.global.error;
+
+import com.example.spark.global.response.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
+        return ResponseEntity.status(ex.getErrorCode().getStatus())
+                .body(ErrorResponse.fromErrorCode(ex.getErrorCode()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGlobalException(Exception ex) {
+        ex.printStackTrace(); // 로그 확인용
+        return ResponseEntity.status(ErrorCode.UNEXPECTED_ERROR.getStatus())
+                .body(ErrorResponse.fromErrorCode(ErrorCode.UNEXPECTED_ERROR));
+    }
+}

--- a/src/main/java/com/example/spark/global/oauth/GoogleAuthRequest.java
+++ b/src/main/java/com/example/spark/global/oauth/GoogleAuthRequest.java
@@ -3,9 +3,11 @@ package com.example.spark.global.oauth;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class GoogleAuthRequest {
     @Schema(description = "Google Authorization Code", example = "4/0ASVgi3KyVjpomtvUkkR-UFNZti0...")
     private String code;

--- a/src/main/java/com/example/spark/global/response/ErrorResponse.java
+++ b/src/main/java/com/example/spark/global/response/ErrorResponse.java
@@ -1,31 +1,17 @@
 package com.example.spark.global.response;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
+import com.example.spark.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
-@Builder
-public record ErrorResponse<T>(
-        @Schema(example = "400") int statusCode,
-        @Schema(example = "요청이 잘못되었습니다.") String message,
-        T errorDetails) {
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private final int status;
+    private final String code;
+    private final String message;
 
-    public static <T> ErrorResponse<T> badRequest(T errorDetails) {
-        return new ErrorResponse<>(400, "요청이 잘못되었습니다.", errorDetails);
-    }
-
-    public static <T> ErrorResponse<T> unauthorized(T errorDetails) {
-        return new ErrorResponse<>(401, "인증이 필요합니다.", errorDetails);
-    }
-
-    public static <T> ErrorResponse<T> forbidden(T errorDetails) {
-        return new ErrorResponse<>(403, "접근 권한이 없습니다.", errorDetails);
-    }
-
-    public static <T> ErrorResponse<T> notFound(T errorDetails) {
-        return new ErrorResponse<>(404, "요청한 리소스를 찾을 수 없습니다.", errorDetails);
-    }
-
-    public static <T> ErrorResponse<T> internalServerError(T errorDetails) {
-        return new ErrorResponse<>(500, "서버 내부 오류가 발생했습니다.", errorDetails);
+    public static ErrorResponse fromErrorCode(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getStatus(), errorCode.getCode(), errorCode.getMessage());
     }
 }

--- a/src/main/java/com/example/spark/global/response/GoogleTokenResponse.java
+++ b/src/main/java/com/example/spark/global/response/GoogleTokenResponse.java
@@ -1,12 +1,23 @@
 package com.example.spark.global.response;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.example.spark.global.error.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL) // null 값 필드는 응답에서 제외
 public class GoogleTokenResponse {
+
     @JsonProperty("access_token")
     private String accessToken;
 
     @JsonProperty("expires_in")
-    private int expiresIn;
+    private Integer expiresIn;
 
     @JsonProperty("refresh_token")
     private String refreshToken;
@@ -17,72 +28,16 @@ public class GoogleTokenResponse {
     @JsonProperty("token_type")
     private String tokenType;
 
-    private String error;
-    private String errorDescription;
+    private Integer status;
+    private String code;
+    private String message;
 
-    // 기본 생성자
-    public GoogleTokenResponse() {}
-
-    // 새로운 생성자 추가
-    public GoogleTokenResponse(String error, String errorDescription) {
-        this.error = error;
-        this.errorDescription = errorDescription;
-    }
-
-    // Getters and Setters
-    public String getAccessToken() {
-        return accessToken;
-    }
-
-    public void setAccessToken(String accessToken) {
-        this.accessToken = accessToken;
-    }
-
-    public int getExpiresIn() {
-        return expiresIn;
-    }
-
-    public void setExpiresIn(int expiresIn) {
-        this.expiresIn = expiresIn;
-    }
-
-    public String getRefreshToken() {
-        return refreshToken;
-    }
-
-    public void setRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
-
-    public String getScope() {
-        return scope;
-    }
-
-    public void setScope(String scope) {
-        this.scope = scope;
-    }
-
-    public String getTokenType() {
-        return tokenType;
-    }
-
-    public void setTokenType(String tokenType) {
-        this.tokenType = tokenType;
-    }
-
-    public String getError() {
-        return error;
-    }
-
-    public void setError(String error) {
-        this.error = error;
-    }
-
-    public String getErrorDescription() {
-        return errorDescription;
-    }
-
-    public void setErrorDescription(String errorDescription) {
-        this.errorDescription = errorDescription;
+    /**
+     * 오류 응답을 위한 생성자
+     */
+    public GoogleTokenResponse(ErrorCode errorCode) {
+        this.status = errorCode.getStatus();
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
     }
 }


### PR DESCRIPTION
에러코드를 이용한 CustomException 구현 
---

- FE 파트 요청에 따라 API 별로 HTTP 상태코드에 따른 Custom한 Response를 구현하였습니다. 
- 급한대로 Auth 관련된 코드에만 적용을 하였고 추후 모든 API에 올바른 Error와 Success 응답을 만들 예정입니다. 
- 프로젝트 진행 중 비호환성으로 인한 문제가 발생하여 해결했고, 해당 문제는 https://triangular-trombone-8fb.notion.site/CustomException-1a3ea985e0f280829045e45433e8ac7c?pvs=4 에 정리해놓았음.

<img width="385" alt="image" src="https://github.com/user-attachments/assets/fdc0ca10-ec64-43c4-99b2-ee472ceef373" />
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/a1f02dd7-6379-43e1-91bd-47a02a739f36" />
