### PR TITLE
feat: Gathering profile info

### DIFF
--- a/src/main/java/com/example/spark/domain/meta/api/MetaController.java
+++ b/src/main/java/com/example/spark/domain/meta/api/MetaController.java
@@ -1,0 +1,55 @@
+package com.example.spark.domain.meta.api;
+
+import com.example.spark.domain.meta.dto.MetaProfileDto;
+import com.example.spark.domain.meta.service.MetaService;
+import com.example.spark.global.error.CustomException;
+import com.example.spark.global.error.ErrorCode;
+import com.example.spark.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Meta API", description = "Meta(Instagram) 데이터를 관리하는 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/meta")
+public class MetaController {
+
+    private final MetaService metaService;
+
+    @Operation(
+            summary = "채널 정보 조회",
+            description = """
+                    연동된 채널의 프로필을 조회합니다.
+                                          
+                    **요청값**
+                    - `accessToken`: Meta API 인증에 필요한 액세스 토큰
+                    - `instagram_business_account_id`: Instagram 비즈니스 계정 ID  
+                                        
+                    **응답값**
+                    - 유저명
+                    - 프로필 URL
+                    - 팔로워 수 
+                    - 팔로잉 수 
+                    - 게시글 수
+                    """
+    )
+    @GetMapping("/account-profile")
+    public SuccessResponse<MetaProfileDto> getAccountProfile(
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader) {
+
+        // "Bearer " 제거 후 액세스 토큰만 추출
+        String accessToken = authorizationHeader.substring(7);
+
+        try {
+            MetaProfileDto profile = metaService.getAccountProfile(accessToken);
+            return SuccessResponse.success(profile);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.ACCESS_TOKEN_EXPIRED);
+        }
+    }
+}

--- a/src/main/java/com/example/spark/domain/meta/dto/MetaProfileDto.java
+++ b/src/main/java/com/example/spark/domain/meta/dto/MetaProfileDto.java
@@ -1,0 +1,18 @@
+package com.example.spark.domain.meta.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MetaProfileDto {
+    private String userName;
+    private String profileUrl;
+    private Long followersCount;
+    private Long followingCount;
+    private Long postsCount;
+}

--- a/src/main/java/com/example/spark/domain/meta/service/MetaService.java
+++ b/src/main/java/com/example/spark/domain/meta/service/MetaService.java
@@ -1,0 +1,72 @@
+package com.example.spark.domain.meta.service;
+
+import com.example.spark.domain.meta.dto.MetaProfileDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class MetaService {
+    private final RestTemplate restTemplate;
+
+    public MetaService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    //사용자 프로필 조회
+    public MetaProfileDto getAccountProfile(String accessToken) {
+        if (accessToken == null || accessToken.isEmpty()) {
+            throw new IllegalArgumentException("Access token이 존재하지 않습니다.");
+        }
+
+        // 공통 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        // 1단계: 연결된 페이지에서 Instagram 비즈니스 계정 ID 조회
+        String pageUrl = "https://graph.facebook.com/v22.0/me/accounts?fields=id,name,instagram_business_account";
+
+        ResponseEntity<JsonNode> pageResponse = restTemplate.exchange(
+                pageUrl, HttpMethod.GET, entity, JsonNode.class);
+
+        JsonNode accounts = pageResponse.getBody().get("data");
+
+        if (accounts == null || !accounts.elements().hasNext()) {
+            throw new RuntimeException("연결된 페이지가 없거나 Instagram 계정이 연결되어 있지 않습니다.");
+        }
+
+        JsonNode account = accounts.get(0); // 첫 페이지만 사용
+        JsonNode instagramAccount = account.get("instagram_business_account");
+
+        if (instagramAccount == null || instagramAccount.get("id") == null) {
+            throw new RuntimeException("Instagram 비즈니스 계정이 이 페이지에 연결되어 있지 않습니다.");
+        }
+
+        String igUserId = instagramAccount.get("id").asText();
+
+        // 2단계: Instagram 비즈니스 계정 프로필 정보 조회
+        String profileUrl = "https://graph.facebook.com/v22.0/" + igUserId
+                + "?fields=username,profile_picture_url,followers_count,follows_count,media_count";
+
+        ResponseEntity<JsonNode> profileResponse = restTemplate.exchange(
+                profileUrl, HttpMethod.GET, entity, JsonNode.class);
+
+        JsonNode profile = profileResponse.getBody();
+
+        if (profile == null) {
+            throw new RuntimeException("Instagram 프로필 정보를 가져오지 못했습니다.");
+        }
+
+        return new MetaProfileDto(
+                profile.get("username").asText(),
+                profile.get("profile_picture_url").asText(),
+                profile.get("followers_count").asLong(),
+                profile.get("follows_count").asLong(),
+                profile.get("media_count").asLong());
+    }
+}


### PR DESCRIPTION
인스타 프로필 조회
---

- 연결된 Facebook 페이지에서 Instagram 비즈니스 계정 ID를 조회한 뒤, 해당 계정의 프로필 정보를 가져오는 API를 구현했습니다.
- 두 개의 Graph API 호출 과정을 하나의 API로 통합하였습니다

주요 내용
---
- GET /meta/account-profile API 구현
- 내부적으로 /me/accounts → instagram_business_account.id 조회
- 이후 해당 ID로 Instagram 프로필 정보(username, profile_picture_url 등) 조회
- access token은 Authorization: Bearer <token> 헤더로 처리


_코드를 너무 급하게 짜느라 수정이 매우 필요합니다_

![image](https://github.com/user-attachments/assets/7126e950-01c0-4ff9-b9d0-d6eba1ba0961)