### PR TITLE
feat: remove WMA, use average views per video instead

### DIFF
--- a/src/main/java/com/example/spark/domain/wma/api/PredictionController.java
+++ b/src/main/java/com/example/spark/domain/wma/api/PredictionController.java
@@ -1,6 +1,5 @@
 package com.example.spark.domain.wma.api;
 
-
 import com.example.spark.domain.flask.dto.YouTubeDataCache;
 import com.example.spark.domain.wma.service.PredictionService;
 import com.example.spark.domain.youtube.dto.YouTubeAnalysisResultDto;
@@ -12,41 +11,43 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
-@Tag(name = "Prediction API", description = "3개월 뒤 조회수/구독자수를 계산하는 API")
+@Tag(name = "Average Views API", description = "영상 1개당 평균 조회수를 계산하는 API")
 @RestController
 @RequiredArgsConstructor
 public class PredictionController {
-    private final PredictionService PredictionService;
-    private final YouTubeDataCache YouTubeDataCache;
+    private final PredictionService predictionService;
+    private final YouTubeDataCache youTubeDataCache;
     
     @Operation(
-            summary = "WMA 기반 성장 예측",
+            summary = "영상 1개당 평균 조회수 계산",
             description = """
-                    최근 3개 기간의 조회수/구독자수 데이터를 기반으로
-                    3개월 뒤 조회수/구독자수를 가중 이동 평균(WMA)으로 예측합니다.
+                    최근 3개 기간의 데이터를 기반으로 각 기간별 영상 1개당 평균 조회수를 계산합니다.
+                    
+                    **계산 공식**
+                    - 최근 30일: 최근 30일간 조회수 / 최근 30일간 업로드한 영상수
+                    - 30~60일: 30~60일간 조회수 / 30~60일간 업로드한 영상수  
+                    - 60~90일: 60~90일간 조회수 / 60~90일간 업로드한 영상수
                     
                     **요청값**
                     - `channelId`: 조회할 채널 ID
                     
                     **응답값**
-                    - 3개월 뒤 조회수 예측
-                    - 3개월 뒤 구독자수 예측
+                    - `recent30Days`: 최근 30일 평균 조회수
+                    - `days30to60`: 30~60일 평균 조회수
+                    - `days60to90`: 60~90일 평균 조회수
                     """
     )
-    @GetMapping("/channel-predictions")
-    public SuccessResponse<Map<String, Double>> getWmaPredictions(@RequestParam String channelId) {
-
+    @GetMapping("/average-views-per-video")
+    public SuccessResponse<Map<String, Double>> getAverageViewsPerVideo(@RequestParam String channelId) {
         YouTubeAnalysisResultDto analysisResult = null;
         int retryCount = 0;
         int maxRetries = 3; // 최대 3회 재시도
         int delayMillis = 700; // 0.7초 대기 후 재시도
 
         while (retryCount < maxRetries) {
-            analysisResult = YouTubeDataCache.getAndRemoveData(channelId);
+            analysisResult = youTubeDataCache.getAndRemoveData(channelId);
 
             if (analysisResult != null && analysisResult.getStats().size() >= 3) {
                 break; // 데이터가 충분하면 반복문 탈출
@@ -64,12 +65,12 @@ public class PredictionController {
 
         // 최종적으로도 데이터 부족하면 예외 발생
         if (analysisResult == null || analysisResult.getStats().size() < 3) {
-            throw new RuntimeException("WMA 예측을 위해 최소 3개 기간 데이터가 필요합니다.");
+            throw new RuntimeException("평균 조회수 계산을 위해 최소 3개 기간 데이터가 필요합니다.");
         }
 
-        // WMA 기반 성장 예측 수행
-        Map<String, Double> wmaPredictions = PredictionService.calculateWMAPredictions(analysisResult.getStats());
+        // 영상 1개당 평균 조회수 계산 수행
+        Map<String, Double> averageViews = predictionService.calculateAverageViewsPerVideo(analysisResult.getStats());
 
-        return SuccessResponse.success(wmaPredictions);
+        return SuccessResponse.success(averageViews);
     }
 }

--- a/src/main/java/com/example/spark/domain/wma/service/PredictionService.java
+++ b/src/main/java/com/example/spark/domain/wma/service/PredictionService.java
@@ -6,70 +6,86 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 @Service
 public class PredictionService {
-    public Map<String, Double> calculateWMAPredictions(List<YouTubeCombinedStatsDto> stats) {
+    
+    // YouTube 영상 1개당 평균 조회수 계산
+    public Map<String, Double> calculateAverageViewsPerVideo(List<YouTubeCombinedStatsDto> stats) {
         if (stats.size() < 3) {
-            throw new RuntimeException("WMA 예측을 위해 최소 3개 기간 데이터가 필요합니다.");
+            throw new RuntimeException("평균 조회수 계산을 위해 최소 3개 기간 데이터가 필요합니다.");
         }
 
-        // 가중치 설정 (최근 데이터에 더 높은 가중치)
-        double w1 = 0.5;
-        double w2 = 0.3;
-        double w3 = 0.2;
+        Map<String, Double> averageViews = new LinkedHashMap<>(); // 순서 보장
 
-        // 최근 3개 기간 데이터
-        double recentViews = stats.get(0).getViews();
-        double midViews = stats.get(1).getViews();
-        double oldViews = stats.get(2).getViews();
+        // recent30Days
+        YouTubeCombinedStatsDto stat0 = stats.get(0);
+        double totalViews0 = stat0.getViews();
+        int uploadedVideos0 = stat0.getUploadedVideos();
+        double avgViews0 = uploadedVideos0 > 0 ? totalViews0 / uploadedVideos0 : 0.0;
+        averageViews.put("recent30Days", Math.round(avgViews0 * 100.0) / 100.0);
 
-        double recentSubscribers = stats.get(0).getNetSubscribers();
-        double midSubscribers = stats.get(1).getNetSubscribers();
-        double oldSubscribers = stats.get(2).getNetSubscribers();
+        // days30to60
+        YouTubeCombinedStatsDto stat1 = stats.get(1);
+        double totalViews1 = stat1.getViews();
+        int uploadedVideos1 = stat1.getUploadedVideos();
+        double avgViews1 = uploadedVideos1 > 0 ? totalViews1 / uploadedVideos1 : 0.0;
+        averageViews.put("days30to60", Math.round(avgViews1 * 100.0) / 100.0);
 
-        // WMA 계산
-        double predictedViews = (w1 * recentViews) + (w2 * midViews) + (w3 * oldViews);
-        double predictedNetSubscribers = (w1 * recentSubscribers) + (w2 * midSubscribers) + (w3 * oldSubscribers);
+        // days60to90
+        YouTubeCombinedStatsDto stat2 = stats.get(2);
+        double totalViews2 = stat2.getViews();
+        int uploadedVideos2 = stat2.getUploadedVideos();
+        double avgViews2 = uploadedVideos2 > 0 ? totalViews2 / uploadedVideos2 : 0.0;
+        averageViews.put("days60to90", Math.round(avgViews2 * 100.0) / 100.0);
 
-        // 결과 반환
-        Map<String, Double> predictions = new HashMap<>();
-        predictions.put("predictedViews", Double.valueOf((int) Math.round(predictedViews)));
-        predictions.put("predictedNetSubscribers", Double.valueOf((int) Math.round(predictedNetSubscribers)));
-
-        return predictions;
+        return averageViews;
     }
 
-    public Map<String, Double> calculateMetaWMAPredictions(List<MetaStatsDto> stats) {
+    // Instagram 미디어 1개당 평균 조회수 계산
+    public Map<String, Double> calculateMetaAverageViewsPerVideo(List<MetaStatsDto> stats) {
         if (stats.size() < 3) {
-            throw new RuntimeException("WMA 예측을 위해 최소 3개 기간 데이터가 필요합니다.");
+            throw new RuntimeException("평균 조회수 계산을 위해 최소 3개 기간 데이터가 필요합니다.");
         }
 
-        // 가중치 설정 (최근 데이터에 더 높은 가중치)
-        double w1 = 0.5;
-        double w2 = 0.3;
-        double w3 = 0.2;
+        Map<String, Double> averageViews = new LinkedHashMap<>(); // 순서 보장
 
-        // 최근 3개 기간 데이터 - 팔로워수
-        double recentFollowers = stats.get(0).getFollowers();
-        double midFollowers = stats.get(1).getFollowers();
-        double oldFollowers = stats.get(2).getFollowers();
+        // recent30Days
+        MetaStatsDto stat0 = stats.get(0);
+        double totalViews0 = stat0.getViewsFollowers() + stat0.getViewsNonFollowers();
+        int uploadedMedia0 = stat0.getUploadedMedia().intValue();
+        double avgViews0 = uploadedMedia0 > 0 ? totalViews0 / uploadedMedia0 : 0.0;
+        averageViews.put("recent30Days", Math.round(avgViews0 * 100.0) / 100.0);
 
-        // 최근 3개 기간 데이터 - 조회수 (follower + non-follower 합계)
-        double recentViews = stats.get(0).getViewsFollowers() + stats.get(0).getViewsNonFollowers();
-        double midViews = stats.get(1).getViewsFollowers() + stats.get(1).getViewsNonFollowers();
-        double oldViews = stats.get(2).getViewsFollowers() + stats.get(2).getViewsNonFollowers();
+        // days30to60
+        MetaStatsDto stat1 = stats.get(1);
+        double totalViews1 = stat1.getViewsFollowers() + stat1.getViewsNonFollowers();
+        int uploadedMedia1 = stat1.getUploadedMedia().intValue();
+        double avgViews1 = uploadedMedia1 > 0 ? totalViews1 / uploadedMedia1 : 0.0;
+        averageViews.put("days30to60", Math.round(avgViews1 * 100.0) / 100.0);
 
-        // WMA 계산
-        double predictedFollowers = (w1 * recentFollowers) + (w2 * midFollowers) + (w3 * oldFollowers);
-        double predictedViews = (w1 * recentViews) + (w2 * midViews) + (w3 * oldViews);
+        // days60to90
+        MetaStatsDto stat2 = stats.get(2);
+        double totalViews2 = stat2.getViewsFollowers() + stat2.getViewsNonFollowers();
+        int uploadedMedia2 = stat2.getUploadedMedia().intValue();
+        double avgViews2 = uploadedMedia2 > 0 ? totalViews2 / uploadedMedia2 : 0.0;
+        averageViews.put("days60to90", Math.round(avgViews2 * 100.0) / 100.0);
 
-        // 결과 반환
-        Map<String, Double> predictions = new HashMap<>();
-        predictions.put("predictedFollowers", Double.valueOf((int) Math.round(predictedFollowers)));
-        predictions.put("predictedViews", Double.valueOf((int) Math.round(predictedViews)));
+        return averageViews;
+    }
 
-        return predictions;
+    // 기간별 키 생성
+    private String getPeriodKey(int index) {
+        switch (index) {
+            case 0:
+                return "recent30Days"; // 최근 30일
+            case 1:
+                return "days30to60";   // 30~60일
+            case 2:
+                return "days60to90";   // 60~90일
+            default:
+                return "period" + (index + 1);
+        }
     }
 }


### PR DESCRIPTION
WMA를 통한 3개월 후 값 예측 기능 삭제 및 업로드 컨텐츠별 조회수 기능 추가
---  

- 기획의 변경에 따라 WMA를 이용한 예측 기능을 없애고, 대신 영상 1개당 평균 조회수 기능을 구현하였습니다. 
- WMA 값을 호출할 때처럼 캐시된 Meta/Youtube 통계 데이터를 가져와서, 그 데이터를 기반으로 평균 조회수를 계산합니다.  
- 영상 1개당 평균 좋아요/댓글수 & 조회수 1회당 신규 팔로워수도 추가할 예정입니다. 


![image](https://github.com/user-attachments/assets/6a195b08-8f2b-4186-b8bd-d84ffcc64a84)
![image](https://github.com/user-attachments/assets/131b3d67-96d8-4a1f-82fe-40e76d4058f3)
