### PR TITLE
Feature/gathering meta data

### DIFF
--- a/src/main/java/com/example/spark/domain/meta/dto/MetaStatsDto.java
+++ b/src/main/java/com/example/spark/domain/meta/dto/MetaStatsDto.java
@@ -13,6 +13,8 @@ public class MetaStatsDto {
     private String startDate;
     private String endDate;
     private Long impressions; // likes + comments + saves + shares
+    private Long likes; // 개별 좋아요 수
+    private Long comments; // 개별 댓글 수
     private Long profileStats; // profile_views + profile_links_taps
     private Long followers;
     private Long unfollowers;

--- a/src/main/java/com/example/spark/domain/meta/service/MetaService.java
+++ b/src/main/java/com/example/spark/domain/meta/service/MetaService.java
@@ -200,6 +200,8 @@ public class MetaService {
                     .startDate(dateRange.getStartDate())
                     .endDate(dateRange.getEndDate())
                     .impressions(insightsData.get("impressions"))
+                    .likes(insightsData.get("likes"))
+                    .comments(insightsData.get("comments"))
                     .profileStats(insightsData.get("profileStats"))
                     .followers(insightsData.get("followers"))
                     .unfollowers(insightsData.get("unfollowers"))
@@ -268,6 +270,8 @@ public class MetaService {
 
         Map<String, Long> result = new HashMap<>();
         result.put("impressions", 0L);
+        result.put("likes", 0L);
+        result.put("comments", 0L);
         result.put("profileStats", 0L);
         result.put("followers", 0L);
         result.put("unfollowers", 0L);
@@ -291,9 +295,19 @@ public class MetaService {
 
                 switch (name) {
                     case "likes":
+                        result.put("likes", value);
+                        result.put("impressions", result.get("impressions") + value);
+                        break;
                     case "comments":
+                        result.put("comments", value);
+                        result.put("impressions", result.get("impressions") + value);
+                        break;
                     case "saves":
+                        result.put("saves", value);
+                        result.put("impressions", result.get("impressions") + value);
+                        break;
                     case "shares":
+                        result.put("shares", value);
                         result.put("impressions", result.get("impressions") + value);
                         break;
                     case "profile_views":

--- a/src/main/java/com/example/spark/domain/youtube/api/YouTubeStatisticsController.java
+++ b/src/main/java/com/example/spark/domain/youtube/api/YouTubeStatisticsController.java
@@ -12,9 +12,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.HashMap;
 import java.util.Map;
 
-@Tag(name = "YouTube(Google) - Statistics", description = "YouTube 영상 1개당 평균 조회수 통계 API")
+@Tag(name = "YouTube(Google) - Statistics", description = "YouTube 영상 1개당 평균 통계 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/youtube")
@@ -23,26 +24,38 @@ public class YouTubeStatisticsController {
     private final YouTubeDataCache youTubeDataCache;
 
     @Operation(
-            summary = "YouTube 영상 1개당 평균 조회수 계산",
+            summary = "YouTube 영상 1개당 평균 성과 지표",
             description = """
-                    최근 3개 기간의 데이터를 기반으로 각 기간별 영상 1개당 평균 조회수를 계산합니다.
+                    최근 3개 기간의 데이터를 기반으로 각 기간별 영상 1개당 평균 조회수, 좋아요수, 댓글수를 계산합니다.
                     
                     **계산 공식**
-                    - 최근 30일: 최근 30일간 조회수 / 최근 30일간 업로드한 영상수
-                    - 30~60일: 30~60일간 조회수 / 30~60일간 업로드한 영상수  
-                    - 60~90일: 60~90일간 조회수 / 60~90일간 업로드한 영상수
+                    - 평균 조회수 = 총 조회수 / 업로드한 영상수
+                    - 평균 좋아요수 = 총 좋아요수 / 업로드한 영상수
+                    - 평균 댓글수 = 총 댓글수 / 업로드한 영상수
                     
                     **요청값**
                     - `channelId`: 조회할 YouTube 채널 ID
                     
                     **응답값**
-                    - `recent30Days`: 최근 30일 평균 조회수
-                    - `days30to60`: 30~60일 평균 조회수
-                    - `days60to90`: 60~90일 평균 조회수
+                    - `averageViews`: 기간별 평균 조회수
+                    - `averageLikes`: 기간별 평균 좋아요수
+                    - `averageComments`: 기간별 평균 댓글수
                     """
     )
-    @GetMapping("/statistics/average-views")
-    public SuccessResponse<Map<String, Double>> getYouTubeAverageViews(@RequestParam String channelId) {
+    @GetMapping("/statistics/performance")
+    public SuccessResponse<Map<String, Object>> getYouTubePerformance(@RequestParam String channelId) {
+        YouTubeAnalysisResultDto analysisResult = getAnalysisResult(channelId);
+        
+        Map<String, Object> performance = new HashMap<>();
+        performance.put("averageViews", youTubeStatisticsService.calculateYouTubeAverageViews(analysisResult.getStats()));
+        performance.put("averageLikes", youTubeStatisticsService.calculateYouTubeAverageLikes(analysisResult.getStats()));
+        performance.put("averageComments", youTubeStatisticsService.calculateYouTubeAverageComments(analysisResult.getStats()));
+        
+        return SuccessResponse.success(performance);
+    }
+    
+    // 공통 데이터 조회 메서드
+    private YouTubeAnalysisResultDto getAnalysisResult(String channelId) {
         YouTubeAnalysisResultDto analysisResult = null;
         int retryCount = 0;
         int maxRetries = 3; // 최대 3회 재시도
@@ -67,12 +80,9 @@ public class YouTubeStatisticsController {
 
         // 최종적으로도 데이터 부족하면 예외 발생
         if (analysisResult == null || analysisResult.getStats().size() < 3) {
-            throw new RuntimeException("평균 조회수 계산을 위해 최소 3개 기간 데이터가 필요합니다.");
+            throw new RuntimeException("평균 통계 계산을 위해 최소 3개 기간 데이터가 필요합니다.");
         }
-
-        // 영상 1개당 평균 조회수 계산 수행
-        Map<String, Double> averageViews = youTubeStatisticsService.calculateYouTubeAverageViews(analysisResult.getStats());
-
-        return SuccessResponse.success(averageViews);
+        
+        return analysisResult;
     }
 } 


### PR DESCRIPTION
**Meta/YouTube 통계 기능 개선 및 코드 리팩토링**
---
### 상세 변경사항

#### Meta 통계 기능 개선
- `MetaStatsDto`에 `likes`, `comments` 필드 추가 (개별 평균 계산을 위해)
- `MetaService`에서 개별 지표 수집 및 `impressions` 계산 로직 개선
- `MetaStatisticsService` 코드 중복 제거 및 리팩토링
  - `validateStatsSize()`, `calculateAverage()` 공통 메서드 추출
  - `calculateMetaAverageLikes()`, `calculateMetaAverageComments()` 메서드 추가
- `/statistics/average-views` → `/statistics/performance` 엔드포인트 변경
  - 평균 조회수, 좋아요수, 댓글수를 모두 반환하도록 확장

#### YouTube 통계 기능 추가
- `YouTubeStatisticsService` 코드 중복 제거 및 리팩토링
  - `validateStatsSize()`, `calculateAverage()` 공통 메서드 추출
  - `calculateYouTubeAverageLikes()`, `calculateYouTubeAverageComments()` 메서드 추가
- `/statistics/average-views` → `/statistics/performance` 엔드포인트 통합
  - 평균 조회수, 좋아요수, 댓글수를 모두 반환하는 단일 엔드포인트
- Meta와 YouTube API 일관성 확보

#### 코드 품질 개선
- 중복 코드 제거 및 공통 메서드 추출
- 일관된 엔드포인트 네이밍 (`/statistics/performance`)


<img width="706" height="353" alt="image" src="https://github.com/user-attachments/assets/d0e626af-ada3-4974-a058-d1de884f8a4f" />
<img width="1055" height="350" alt="image" src="https://github.com/user-attachments/assets/97cceb7c-d160-47b5-a889-cddfe7f56b47" />
